### PR TITLE
makefile: ensure Quicklisp is loaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,14 @@ all: test
 
 build:
 	$(LISP)	--non-interactive \
+		--eval '#-quicklisp (let ((quicklisp-init (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))) (when (probe-file quicklisp-init) (load quicklisp-init)))' \
 		--load replic.asd \
 		--eval '(ql:quickload :replic)' \
 		--eval '(asdf:make :replic)'
 
 test:
 	$(LISP) --non-interactive \
+		--eval '#-quicklisp (let ((quicklisp-init (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))) (when (probe-file quicklisp-init) (load quicklisp-init)))' \
 		--load replic.asd \
 		--load replic-test.asd \
 		--eval '(ql:quickload :replic)' \


### PR DESCRIPTION
for #1 

@svetlyak40wt this fixes the case of not having anything in the .sbclrc.
